### PR TITLE
Fix for strange crash opening flat docs xml

### DIFF
--- a/ooodev/office/calc.py
+++ b/ooodev/office/calc.py
@@ -10,7 +10,12 @@ import os
 from typing import Any, List, Tuple, cast, overload, Sequence, TYPE_CHECKING
 import uno
 
-_DOCS_BUILDING = True if os.environ.get("DOCS_BUILDING", None) in ("True", "true") else False
+_DOCS_BUILDING = os.environ.get("DOCS_BUILDING", None) == 'True'
+# _DOCS_BUILDING is only true when sphinx is building docs.
+# env var DOCS_BUILDING is set in docs/conf.py
+_ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
+# env var READTHEDOCS is true when read the docs is building
+# maybe not needed as _DOCS_BUILDING is set in conf.py
 
 from com.sun.star.sheet import CellFlags as UnoCellFlags # const
 from com.sun.star.sheet.GeneralFunction import (
@@ -41,53 +46,53 @@ from com.sun.star.table.CellContentType import (
     TEXT as CCT_TEXT,
     FORMULA as CCT_FORMULA,
 )
-
-# if not _DOCS_BUILDING:
-from com.sun.star.sheet.CellDeleteMode import LEFT as DM_LEFT, UP as DM_UP
-from com.sun.star.sheet.CellInsertMode import RIGHT as IM_RIGHT, DOWN as IM_DOWN
-# from com.sun.star.sheet.FillDateMode import FILL_DATE_DAY # enum
 from com.sun.star.awt import Point
-from com.sun.star.container import XIndexAccess
-from com.sun.star.container import XNamed
-from com.sun.star.frame import XModel
-from com.sun.star.lang import XComponent
-from com.sun.star.lang import Locale
-from com.sun.star.sheet import SolverConstraint  # struct
-from com.sun.star.sheet import XCellAddressable
-from com.sun.star.sheet import XCellRangeData
-from com.sun.star.sheet import XCellRangeAddressable
-from com.sun.star.sheet import XCellRangeMovement
-from com.sun.star.sheet import XCellSeries
-from com.sun.star.sheet import XDataPilotTable
-from com.sun.star.sheet import XDataPilotTablesSupplier
-from com.sun.star.sheet import XFunctionAccess
-from com.sun.star.sheet import XFunctionDescriptions
-from com.sun.star.sheet import XHeaderFooterContent
-from com.sun.star.sheet import XRecentFunctions
-from com.sun.star.sheet import XScenario
-from com.sun.star.sheet import XScenariosSupplier
-from com.sun.star.sheet import XSpreadsheet
-from com.sun.star.sheet import XSpreadsheetDocument
-from com.sun.star.sheet import XSpreadsheetView
-from com.sun.star.sheet import XSheetAnnotationAnchor
-from com.sun.star.sheet import XSheetAnnotationsSupplier
-from com.sun.star.sheet import XSheetCellRange
-from com.sun.star.sheet import XSheetOperation
-from com.sun.star.sheet import XSpreadsheets
-from com.sun.star.sheet import XUsedAreaCursor
-from com.sun.star.sheet import XViewPane
-from com.sun.star.sheet import XViewFreezable
-from com.sun.star.style import XStyle
-from com.sun.star.table import BorderLine2  # struct
-from com.sun.star.table import TableBorder2  # struct
-from com.sun.star.table import XColumnRowRange
-from com.sun.star.table import XCellRange
 
-from com.sun.star.text import XSimpleText
-from com.sun.star.uno import Exception as UnoException
-from com.sun.star.util import NumberFormat  # const
-from com.sun.star.util import XNumberFormatsSupplier
-from com.sun.star.util import XNumberFormatTypes
+if not _DOCS_BUILDING and not _ON_RTD:
+    # not importing for doc building jus result in short import name for
+    # args that use these.
+    # this is also true becuase docs/conf.py ignores com import for autodoc
+    from com.sun.star.container import XIndexAccess
+    from com.sun.star.container import XNamed
+    from com.sun.star.frame import XModel
+    from com.sun.star.lang import XComponent
+    from com.sun.star.lang import Locale
+    from com.sun.star.sheet import SolverConstraint  # struct
+    from com.sun.star.sheet import XCellAddressable
+    from com.sun.star.sheet import XCellRangeData
+    from com.sun.star.sheet import XCellRangeAddressable
+    from com.sun.star.sheet import XCellRangeMovement
+    from com.sun.star.sheet import XCellSeries
+    from com.sun.star.sheet import XDataPilotTable
+    from com.sun.star.sheet import XDataPilotTablesSupplier
+    from com.sun.star.sheet import XFunctionAccess
+    from com.sun.star.sheet import XFunctionDescriptions
+    from com.sun.star.sheet import XHeaderFooterContent
+    from com.sun.star.sheet import XRecentFunctions
+    from com.sun.star.sheet import XScenario
+    from com.sun.star.sheet import XScenariosSupplier
+    from com.sun.star.sheet import XSpreadsheet
+    from com.sun.star.sheet import XSpreadsheetDocument
+    from com.sun.star.sheet import XSpreadsheetView
+    from com.sun.star.sheet import XSheetAnnotationAnchor
+    from com.sun.star.sheet import XSheetAnnotationsSupplier
+    from com.sun.star.sheet import XSheetCellRange
+    from com.sun.star.sheet import XSheetOperation
+    from com.sun.star.sheet import XSpreadsheets
+    from com.sun.star.sheet import XUsedAreaCursor
+    from com.sun.star.sheet import XViewPane
+    from com.sun.star.sheet import XViewFreezable
+    from com.sun.star.style import XStyle
+    from com.sun.star.table import BorderLine2  # struct
+    from com.sun.star.table import TableBorder2  # struct
+    from com.sun.star.table import XColumnRowRange
+    from com.sun.star.table import XCellRange
+
+    from com.sun.star.text import XSimpleText
+    from com.sun.star.uno import Exception as UnoException
+    from com.sun.star.util import NumberFormat  # const
+    from com.sun.star.util import XNumberFormatsSupplier
+    from com.sun.star.util import XNumberFormatTypes
 
 if TYPE_CHECKING:
     from com.sun.star.beans import PropertyValue
@@ -97,6 +102,8 @@ if TYPE_CHECKING:
     from com.sun.star.frame import XFrame
 
     # from com.sun.star.sheet import CellAnnotation
+    from com.sun.star.sheet import  CellDeleteMode as UnoCellDeleteMode # enum
+    from com.sun.star.sheet import CellInsertMode as UnoCellInsertMode # enum
     from com.sun.star.sheet import FunctionArgument  # struct
     from com.sun.star.sheet import XSheetAnnotation
     from com.sun.star.sheet import XDataPilotTables
@@ -255,7 +262,6 @@ class Calc:
 
 
     FillDateMode = cast("UnoFillDateMode", UnoEnum("com.sun.star.sheet.FillDateMode"))
-
     # endregion classes
 
     # region Constants
@@ -1237,12 +1243,13 @@ class Calc:
             cell_range (XCellRange): Cell range to insert
             is_shift_right (bool): If True then cell are inserted to the right; Otherwise, inserted down.
         """
+        CellInsertMode = cast("UnoCellInsertMode", UnoEnum("com.sun.star.sheet.CellInsertMode"))
         mover = mLo.Lo.qi(XCellRangeMovement, sheet)
         addr = cls.get_address(cell_range)
         if is_shift_right:
-            mover.insertCells(addr, IM_RIGHT)
+            mover.insertCells(addr, CellInsertMode.RIGHT)
         else:
-            mover.insertCells(addr, IM_DOWN)
+            mover.insertCells(addr, CellInsertMode.DOWN)
 
     @classmethod
     def delete_cells(cls, sheet: XSpreadsheet, cell_range: XCellRange, is_shift_left: bool) -> None:
@@ -1254,12 +1261,13 @@ class Calc:
             cell_range (XCellRange): Cell range to delete
             is_shift_left (bool): If True then cell are shifted left; Otherwise, cells are shifted up.
         """
+        CellDeleteMode = cast("UnoCellDeleteMode", UnoEnum("com.sun.star.sheet.CellDeleteMode"))
         mover = mLo.Lo.qi(XCellRangeMovement, sheet)
         addr = cls.get_address(cell_range)
         if is_shift_left:
-            mover.removeRange(addr, DM_LEFT)
+            mover.removeRange(addr, CellDeleteMode.LEFT)
         else:
-            mover.removeRange(addr, DM_UP)
+            mover.removeRange(addr, CellDeleteMode.UP)
 
     # region    clear_cells()
     @overload

--- a/ooodev/office/write.py
+++ b/ooodev/office/write.py
@@ -18,9 +18,18 @@ from ..utils.color import CommonColor, Color
 from ..utils.uno_enum import UnoEnum
 from ..utils.type_var import PathOrStr, Table
 
-_DOCS_BUILDING = True if os.environ.get("DOCS_BUILDING", None) in ("True", "true") else False
+_DOCS_BUILDING = os.environ.get("DOCS_BUILDING", None) == 'True'
+# _DOCS_BUILDING is only true when sphinx is building docs.
+# env var DOCS_BUILDING is set in docs/conf.py
+_ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
+# env var READTHEDOCS is true when read the docs is building
+# maybe not needed as _DOCS_BUILDING is set in conf.py
 
-if not _DOCS_BUILDING:
+
+if not _DOCS_BUILDING and not _ON_RTD:
+    # not importing for doc building jus result in short import name for
+    # args that use these.
+    # this is also true becuase docs/conf.py ignores com import for autodoc
     from com.sun.star.awt import FontWeight
     from com.sun.star.awt import Size  # struct
     from com.sun.star.beans import XPropertySet

--- a/ooodev/utils/lo.py
+++ b/ooodev/utils/lo.py
@@ -557,7 +557,11 @@ class Lo(metaclass=StaticProperty):
         """
         nn = mXML.XML.get_flat_fiter_name(doc_type=doc_type)
         print(f"Flat filter Name: {nn}")
-        return cls.open_doc(fnm, loader, mProps.Props.make_props(FilterName=nn, Hidden=True))
+        # do not set Hidden=True property here.
+        # there is a strange error that pops up conditionally and it seems
+        # to be remedied by not seting Hidden=True
+        # see comments in tests.text_xml.test_in_filters.test_transform_clubs()
+        return cls.open_doc(fnm, loader, mProps.Props.make_props(FilterName=nn))
 
     @overload
     @classmethod

--- a/ooodev/utils/uno_enum.py
+++ b/ooodev/utils/uno_enum.py
@@ -151,10 +151,7 @@ else:
                 # Provide the caller attributes in whatever ways interest you.
                 try:
                     key = __name
-                    if _DOCS_BUILDING:
-                        e = _MockEnum(self._type_name, __name)
-                    else:
-                        e = uno.Enum(self._type_name, __name)
+                    e = uno.Enum(self._type_name, __name)
                     self.__dict__[key] = e
                     return self.__dict__[key]
                 except Exception:

--- a/tests/test_xml/test_in_filter.py
+++ b/tests/test_xml/test_in_filter.py
@@ -36,7 +36,7 @@ def test_transform_pay(loader, copy_fix_xml) -> None:
     - get the expected range and test
     """
     visible = False
-    delay = 0 # 2000
+    delay = 0 # 1000
     pay_import = copy_fix_xml("payImport.xsl")
     pay = copy_fix_xml("pay.xml")
     
@@ -55,13 +55,13 @@ def test_transform_pay(loader, copy_fix_xml) -> None:
     assert doc_type == Lo.DocTypeStr.CALC
     doc = Lo.open_flat_doc(fnm=flat_fnm, doc_type=doc_type, loader=loader)
     assert doc is not None
-    if visible:
-        GUI.set_visible(is_visible=visible, odoc=doc)
+    GUI.set_visible(is_visible=visible, odoc=doc)
     
     Lo.delay(delay)
     Lo.save_doc(doc=doc, fnm=ods_fnm)
     Lo.close_doc(doc=doc)
-    
+    Lo.delay(1000)
+
     doc = Calc.open_doc(fnm=ods_fnm, loader=loader)
     sheet = Calc.get_sheet(doc=doc, index=0)
 
@@ -88,6 +88,7 @@ def test_transform_pay(loader, copy_fix_xml) -> None:
     assert arr[4][3] == 39511.0
     
     Lo.close(closeable=doc, deliver_ownership=False)
+    Lo.delay(1000)
     
 def test_transform_clubs(loader, copy_fix_xml) -> None:
     """
@@ -101,8 +102,23 @@ def test_transform_clubs(loader, copy_fix_xml) -> None:
     - Open saved Write doc
     - get lines and test
     """
+    # for unknown reason gettin a strange fail on Ubuntu 20.04. Not tested on other os at this time.
+    # tests/test_xml/test_in_filter.py .terminate called after throwing an instance of 'com::sun::star::lang::DisposedException'
+    # If this test is run via VS Code plugin it passes. If run command line via pytest tests/ then if conditionally fails.
+    # the conditions are as follows:
+    #   Is not giving error in Calc
+    #   Is only erroring if window visibality is false. Setting visibility after document is loaded seems ok.
+    #   Is only erroring when opening a flat doc ( in Write ).
+    #
+    # Solution:
+    # The current working solution is to not have flat docs open hidden. This was the case in the original java code.
+    # changes in Lo.open_flat_doc()
+    #       Changed
+    #       return cls.open_doc(fnm, loader, mProps.Props.make_props(FilterName=nn, Hidden=False))
+    #       To
+    #       return cls.open_doc(fnm, loader, mProps.Props.make_props(FilterName=nn))
     visible = False
-    delay = 0 # 2000
+    delay = 0 # 1000
     clubs_import = copy_fix_xml("clubsImport.xsl")
     clubs = copy_fix_xml("clubs.xml")
     
@@ -121,12 +137,12 @@ def test_transform_clubs(loader, copy_fix_xml) -> None:
     assert doc_type == Lo.DocTypeStr.WRITER
     doc = Lo.open_flat_doc(fnm=flat_fnm, doc_type=doc_type, loader=loader)
     assert doc is not None
-    if visible:
-        GUI.set_visible(is_visible=visible, odoc=doc)
+    GUI.set_visible(is_visible=visible, odoc=doc)
     
     Lo.delay(delay)
     Lo.save_doc(doc=doc, fnm=odt_fnm)
     Lo.close_doc(doc=doc)
+    Lo.delay(1000)
     
     doc = Write.open_doc(fnm=odt_fnm, loader=loader)
 
@@ -148,4 +164,5 @@ def test_transform_clubs(loader, copy_fix_xml) -> None:
     assert lines[1361] == "Contact: Randy Campbell"
     assert lines[1928] == "Nipomo Youth Wrestling Club I28"
     
-    Lo.close(closeable=doc, deliver_ownership=False)
+    Lo.close(closeable=doc, deliver_ownership=True)
+    Lo.delay(1000)


### PR DESCRIPTION
see comments in tests.text_xml.test_in_filters.test_transform_clubs()
for unknown reason gettin a strange fail on Ubuntu 20.04. Not tested on other os at this time.
 tests/test_xml/test_in_filter.py .terminate called after throwing an instance of 'com::sun::star::lang::DisposedException'
 If this test is run via VS Code plugin it passes. If run command line via pytest tests/ then if conditionally fails.
 the conditions are as follows:
   Is not giving error in Calc
   Is only erroring if window visibality is false. Setting visibility after document is loaded seems ok.
   Is only erroring when opening a flat doc ( in Write ).

 Solution:
 The current working solution is to not have flat docs open hidden. This was the case in the original java code.
 changes in Lo.open_flat_doc()
       Changed
       return cls.open_doc(fnm, loader, mProps.Props.make_props(FilterName=nn, Hidden=False))
       To
       return cls.open_doc(fnm, loader, mProps.Props.make_props(FilterName=nn))