### PR TITLE
fix for Name attribute on some shapes in custom properties for a sheet

### DIFF
--- a/docs/version/version_hist.rst
+++ b/docs/version/version_hist.rst
@@ -2,6 +2,11 @@
 Version History
 ***************
 
+Version 0.47.15
+===============
+
+Minor fix for some shapes not having a Name attribute when parsing custom properties in a Calc Sheet.
+
 Version 0.47.14
 ===============
 

--- a/ooodev/__init__.py
+++ b/ooodev/__init__.py
@@ -4,7 +4,7 @@
 # with open(os.path.join(os.path.dirname(__file__), "VERSION"), "r", encoding="utf-8") as f:
 #     version = f.read().strip()
 
-__version__ = "0.47.14"
+__version__ = "0.47.15"
 
 
 def get_version() -> str:

--- a/ooodev/calc/cell/custom_prop.py
+++ b/ooodev/calc/cell/custom_prop.py
@@ -176,6 +176,10 @@ class CustomProp(CustomPropBase):
         for shape in comp:  # type: ignore
             if not shape.supportsService("com.sun.star.drawing.ControlShape"):
                 continue
+            if not hasattr(shape, "Name"):
+                # Added in Version 0.47.15
+                # Some shapes do not have a name attribute. Just ignore them here.
+                continue
 
             anchor = shape.Anchor
             if anchor is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ooo-dev-tools"
-version = "0.47.14"
+version = "0.47.15"
 
 description = "LibreOffice Developer Tools"
 license = "Apache Software License"


### PR DESCRIPTION
This pull request includes updates to version 0.47.15, which involves a minor fix for handling shapes without a Name attribute in Calc Sheets, and corresponding version updates in the project files.

### Version Updates:

* [`docs/version/version_hist.rst`](diffhunk://#diff-aeaccdc0a7afb1bc10deea7c944aafd1c543c01bb0d998762b85fac253457a7aR5-R9): Added an entry for version 0.47.15, documenting the minor fix for shapes without a Name attribute.
* [`ooodev/__init__.py`](diffhunk://#diff-0bf995c3a2b1d7521e8c92bdb712716233f214e6ed55078c5063f0da92aa9bfcL7-R7): Updated the `__version__` variable to "0.47.15".
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version to "0.47.15".

### Bug Fixes:

* [`ooodev/calc/cell/custom_prop.py`](diffhunk://#diff-fd613801c2b1d507f002ea3dd737ad2d23b0032b2ba2b3ffc7ff1db63b4fba03R179-R182): Added a check to ignore shapes that do not have a Name attribute when parsing custom properties.