### PR TITLE
fix for custom property shapes not having supportsService attribute

### DIFF
--- a/docs/version/version_hist.rst
+++ b/docs/version/version_hist.rst
@@ -2,6 +2,11 @@
 Version History
 ***************
 
+Version 0.47.16
+===============
+
+Minor fix for some shapes not having a supportsService attribute when parsing custom properties in a Draw Shape.
+
 Version 0.47.15
 ===============
 

--- a/ooodev/__init__.py
+++ b/ooodev/__init__.py
@@ -4,7 +4,7 @@
 # with open(os.path.join(os.path.dirname(__file__), "VERSION"), "r", encoding="utf-8") as f:
 #     version = f.read().strip()
 
-__version__ = "0.47.15"
+__version__ = "0.47.16"
 
 
 def get_version() -> str:

--- a/ooodev/calc/cell/custom_prop.py
+++ b/ooodev/calc/cell/custom_prop.py
@@ -174,11 +174,15 @@ class CustomProp(CustomPropBase):
         cleanup = []
 
         for shape in comp:  # type: ignore
+            if not hasattr(shape, "supportsService"):
+                # Added in Version 0.47.16
+                # Some shapes do not have a supportsService attribute. Just ignore them here.
+                continue
             if not shape.supportsService("com.sun.star.drawing.ControlShape"):
                 continue
             if not hasattr(shape, "Name"):
                 # Added in Version 0.47.15
-                # Some shapes do not have a name attribute. Just ignore them here.
+                # Some shapes do not have a Name attribute. Just ignore them here.
                 continue
 
             anchor = shape.Anchor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ooo-dev-tools"
-version = "0.47.15"
+version = "0.47.16"
 
 description = "LibreOffice Developer Tools"
 license = "Apache Software License"


### PR DESCRIPTION
This pull request includes updates to version 0.47.16, a minor fix for handling shapes in the `ooodev` library, and corresponding documentation updates. The most important changes include updating the version number, adding a fix for shapes without a `supportsService` attribute, and updating the version history documentation.

Version update:

* [`ooodev/__init__.py`](diffhunk://#diff-0bf995c3a2b1d7521e8c92bdb712716233f214e6ed55078c5063f0da92aa9bfcL7-R7): Updated the version number from 0.47.15 to 0.47.16.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the version number from 0.47.15 to 0.47.16.

Bug fix:

* [`ooodev/calc/cell/custom_prop.py`](diffhunk://#diff-fd613801c2b1d507f002ea3dd737ad2d23b0032b2ba2b3ffc7ff1db63b4fba03R177-R185): Added a check to ignore shapes without a `supportsService` attribute when parsing custom properties in a Draw Shape.

Documentation:

* [`docs/version/version_hist.rst`](diffhunk://#diff-aeaccdc0a7afb1bc10deea7c944aafd1c543c01bb0d998762b85fac253457a7aR5-R9): Added version 0.47.16 to the version history with a note about the minor fix.