### PR TITLE
Cell obj

### DIFF
--- a/docs/version/version_hist.rst
+++ b/docs/version/version_hist.rst
@@ -2,6 +2,13 @@
 Version History
 ***************
 
+Version 0.47.17
+===============
+
+Added ``sheet_name`` to ``CellObj``.
+Added ``to_string()`` method to ``CellObj`` that optionally includes the sheet name.
+
+
 Version 0.47.16
 ===============
 

--- a/ooodev/__init__.py
+++ b/ooodev/__init__.py
@@ -4,7 +4,7 @@
 # with open(os.path.join(os.path.dirname(__file__), "VERSION"), "r", encoding="utf-8") as f:
 #     version = f.read().strip()
 
-__version__ = "0.47.16"
+__version__ = "0.47.17"
 
 
 def get_version() -> str:

--- a/ooodev/utils/data_type/range_obj.py
+++ b/ooodev/utils/data_type/range_obj.py
@@ -111,13 +111,16 @@ class RangeObj:
         return self.cell_count
 
     def __copy__(self) -> RangeObj:
-        return RangeObj(
+        ro = RangeObj(
             col_start=self.col_start,
             col_end=self.col_end,
             row_start=self.row_start,
             row_end=self.row_end,
             sheet_idx=self.sheet_idx,
         )
+        if hasattr(self, "_sheet_name"):
+            object.__setattr__(ro, "_sheet_name", getattr(self, "_sheet_name"))
+        return ro
 
     # region methods
 
@@ -282,11 +285,11 @@ class RangeObj:
         Get a string representation of range
 
         Args:
-            include_sheet_name (bool, optional): If ``True`` and there is a sheet name then it is included in format of ``Sheet1.A2.G3``;
+            include_sheet_name (bool, optional): If ``True`` and there is a sheet name then it is included in format of ``Sheet1.A2:G3``;
                 Otherwise format of ``A2:G3``.Defaults to ``False``.
 
         Returns:
-            str: Gets a string representation such as ``A1:T12``/
+            str: Gets a string representation such as ``A1:T12``
         """
         s = f"{self.col_start}{self.row_start}:{self.col_end}{self.row_end}"
         if include_sheet_name and self.sheet_name:
@@ -898,6 +901,8 @@ class RangeObj:
         except AttributeError:
             c = mCellObj.CellObj(col=self.col_start, row=self.row_start, sheet_idx=self.sheet_idx, range_obj=self)
             object.__setattr__(self, "_cell_start", ref(c))
+            if hasattr(self, "_sheet_name"):
+                object.__setattr__(c, "_sheet_name", getattr(self, "_sheet_name"))
         return self._cell_start()  # type: ignore
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ooo-dev-tools"
-version = "0.47.16"
+version = "0.47.17"
 
 description = "LibreOffice Developer Tools"
 license = "Apache Software License"

--- a/tests/test_range/test_cell.py
+++ b/tests/test_range/test_cell.py
@@ -489,3 +489,37 @@ def test_cell_copy(loader) -> None:
     finally:
         if doc is not None:
             doc.close()
+
+
+def test_cell_sheet_name(loader) -> None:
+    from ooodev.utils.data_type.cell_obj import CellObj
+    from ooodev.utils.data_type.range_obj import RangeObj
+
+    from ooodev.calc import CalcDoc
+
+    doc = None
+    try:
+        doc = CalcDoc.create_doc()
+        sheet = doc.sheets[0]
+        sheet.name = "Sheet1"
+        sheet_name = sheet.name
+
+        A1 = CellObj.from_cell(f"{sheet_name}.A1")
+        assert A1.sheet_name == sheet_name
+        assert A1.to_string(True) == f"{sheet_name}.A1"
+        assert str(A1) == "A1"
+        A2 = CellObj.from_cell("A2")
+        A2.set_sheet_index(0)
+        assert A2.sheet_name == sheet_name
+        assert A2.to_string(True) == f"{sheet_name}.A2"
+        assert str(A2) == "A2"
+
+        ro = RangeObj.from_range(f"{sheet_name}.A3:A3")
+        assert ro.is_single_cell()
+        assert ro.start.sheet_name == sheet_name
+        assert ro.start.to_string(True) == f"{sheet_name}.A3"
+        assert str(ro.start) == "A3"
+
+    finally:
+        if doc is not None:
+            doc.close()


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the `ooodev` library, focusing on adding new functionalities to the `CellObj` class, updating version information, and adding new tests. The most important changes include the addition of a `sheet_name` property and a `to_string` method to `CellObj`, updates to version identifiers, and the inclusion of new tests to ensure the correctness of the new features.

### Enhancements to `CellObj` and `RangeObj`:

* Added `to_string` method to `CellObj` to provide a string representation that can optionally include the sheet name. (`ooodev/utils/data_type/cell_obj.py`)
* Introduced a `sheet_name` property to `CellObj` to retrieve the sheet name associated with the cell. (`ooodev/utils/data_type/cell_obj.py`)
* Updated `copy` method in `CellObj` to include the `sheet_name` attribute if it exists. (`ooodev/utils/data_type/cell_obj.py`)
* Enhanced `RangeObj` to include the `sheet_name` attribute in the `copy` method and to correctly format the string representation in `to_string`. (`ooodev/utils/data_type/range_obj.py`) [[1]](diffhunk://#diff-d4bb6e581d80672b8e92fd1d7c0086d27f235fefa2b70ab2993278d4def72cc4L114-R123) [[2]](diffhunk://#diff-d4bb6e581d80672b8e92fd1d7c0086d27f235fefa2b70ab2993278d4def72cc4L285-R292)

### Version Updates:

* Updated version number to `0.47.17` in `__init__.py` and `pyproject.toml`. (`ooodev/__init__.py`, `pyproject.toml`) [[1]](diffhunk://#diff-0bf995c3a2b1d7521e8c92bdb712716233f214e6ed55078c5063f0da92aa9bfcL7-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)
* Documented the new version and added details about the new `sheet_name` property and `to_string` method in the version history. (`docs/version/version_hist.rst`)

### Testing Enhancements:

* Added a new test `test_cell_sheet_name` to verify the functionality of the `sheet_name` property and the `to_string` method in `CellObj`. (`tests/test_range/test_cell.py`)