### PR TITLE
Issue 666 Fix

### DIFF
--- a/ooodev/loader/inst/lo_inst.py
+++ b/ooodev/loader/inst/lo_inst.py
@@ -260,16 +260,19 @@ class LoInst(EventsPartial):
         if event_args.cancel:
             return
         self._clear_cache()
+        # self._xdesktop = None must stay in on_office_closed().
+        # If it were here then office will not terminate.
+        # https://github.com/Amourspirit/python_ooo_dev_tools/issues/666
         self._glb_event_broadcaster = None
         self._current_doc = None
         self._mc_factory = None
-        self._xdesktop = None
         self._xcc = None
         self._fn_on_document_event = None
         self._fn_on_lo_del_cache_attrs = None
         self._logger.debug("on_office_closing() Triggered OFFICE_CLOSING")
 
     def on_office_closed(self, event_args: EventArgs) -> None:
+        self._xdesktop = None
         self._logger.debug("on_office_closed() Triggering OFFICE_CLOSED")
         self.trigger_event(LoNamedEvent.OFFICE_CLOSED, event_args)
         self._logger.debug("on_office_closed() Triggered OFFICE_CLOSED")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ooo-dev-tools"
-version = "0.47.17"
+version = "0.47.18"
 
 description = "LibreOffice Developer Tools"
 license = "Apache Software License"


### PR DESCRIPTION
This pull request includes changes to address a bug in the `on_office_closing` method and an update to the project version in the `pyproject.toml` file.

Bug fix:

* [`ooodev/loader/inst/lo_inst.py`](diffhunk://#diff-6384623af31c158bf2cf2440348e1c1814bb0b53d77e4935cd83e14bc5e9f061R263-R275): Moved the assignment `self._xdesktop = None` from the `on_office_closing` method to the `on_office_closed` method to ensure proper termination of the office instance. Added comments to explain the reason for this change.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version from `0.47.17` to `0.47.18`.