### PR TITLE
update conftest and ver history

### DIFF
--- a/docs/version/version_hist.rst
+++ b/docs/version/version_hist.rst
@@ -2,6 +2,11 @@
 Version History
 ***************
 
+Version 0.47.18
+===============
+
+Fix of issue 666. Calling ``doc.close_office()`` was not working.
+
 Version 0.47.17
 ===============
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import csv
 import os
 import sys
+import contextlib
 from pathlib import Path
 import shutil
 import stat
@@ -247,7 +248,8 @@ def loader(tmp_path_session, run_headless, soffice_path, soffice_env, set_log_fi
         # only close office if it was started by the test
         return
     Lo.close_office()
-    Lo.kill_office()
+    with contextlib.suppress(Exception):
+        Lo.kill_office()
 
 
 # endregion Loader methods


### PR DESCRIPTION
This pull request includes several changes to the documentation and test suite. The most important changes involve updating the version history and improving the test cleanup process.

Documentation updates:

* [`docs/version/version_hist.rst`](diffhunk://#diff-aeaccdc0a7afb1bc10deea7c944aafd1c543c01bb0d998762b85fac253457a7aR5-R9): Added version 0.47.18 with a fix for issue 666, where calling `doc.close_office()` was not working.

Test suite improvements:

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R5): Imported `contextlib` to handle exceptions during the test cleanup process.
* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R251): Modified the `loader` function to use `contextlib.suppress` to ignore exceptions when calling `Lo.kill_office()`.