### PR TITLE
Add unique_id property to CalcCell for consistent cell identification

### DIFF
--- a/docs/version/version_hist.rst
+++ b/docs/version/version_hist.rst
@@ -2,6 +2,11 @@
 Version History
 ***************
 
+Version 0.52.4
+==============
+
+Added ``unique_id`` to ``ooodev.calc.CalcCell``. This unique id is used to identify a cell in a sheet. It will remain constant even if the cell is moved.
+
 Version 0.52.3
 ==============
 

--- a/ooodev/calc/calc_cell.py
+++ b/ooodev/calc/calc_cell.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Any, cast, overload, Sequence, TYPE_CHECKING
 
+from ooodev.utils import gen_util
+
 try:
     # python 3.12+
     from typing import override  # noqa # type: ignore
@@ -133,6 +135,7 @@ class CalcCell(
         StylePropertyPartial.__init__(self, component=sheet_cell, property_name="CellStyle")
         self._control = None
         self._custom_properties = None
+        self._unique_id = None
         self._init_events()
 
     def _init_events(self) -> None:
@@ -809,6 +812,32 @@ class CalcCell(
         cp.remove_custom_properties()
 
     # endregion Custom Properties
+
+    # region Unique Id
+    @property
+    def unique_id(self) -> str:
+        """
+        Gets the unique id of the cell.
+
+        This is a lazy method and does not create a unique id until it is accessed.
+
+        Returns:
+            str: Unique ID
+        """
+        if self._unique_id is None:
+            key = "ooodev.calc.calc_cell.unique_id"
+            value = self.get_custom_property(key, default=None)
+            if value is None:
+                # encode the original cell address into the unique id
+
+                abs_name = self.calc_cell.component.AbsoluteName.encode("utf-8").hex()
+                random = gen_util.Util.generate_random_string(10)
+                value = f"uid_{abs_name}_{random}"
+                self.set_custom_property(key, value)
+            self._unique_id = value
+        return self._unique_id
+
+    # endregion Unique Id
 
     # region Static Methods
 

--- a/ooodev/calc/calc_sheet.py
+++ b/ooodev/calc/calc_sheet.py
@@ -201,7 +201,7 @@ class CalcSheet(
         ...
 
     @overload
-    def rng(self, cell_range: XCellRange) -> mRngObj.RangeObj:
+    def rng(self, cell_range: XCellRange) -> mRngObj.RangeObj:  # type: ignore
         """
         Gets a range Object representing a range.
 
@@ -4006,7 +4006,9 @@ class CalcSheet(
     @property
     def unique_id(self) -> str:
         """
-        Gets the unique name of the sheet.
+        Gets the unique id of the cell.
+
+        This is a lazy method and does not create a unique id until it is accessed.
 
         Returns:
             str: Unique Name

--- a/ooodev/calc/cell/custom_prop_base.py
+++ b/ooodev/calc/cell/custom_prop_base.py
@@ -14,12 +14,21 @@ if TYPE_CHECKING:
 class CustomPropBase(TheDictionaryPartial):
     def __init__(self, sheet: CalcSheet) -> None:
         TheDictionaryPartial.__init__(self)
-        self._shape_prefix = "_cprop_"
-        self._shape_suffix = "_id"  # suffix is important for ensure shape duplicates are removed.
         self._sheet = sheet
-        self._form_name = "CellCustomProperties"
         self._cache = {}
         self._draw_page = self._sheet.draw_page
+        self._shape_prefix = self._get_shape_prefix()
+        self._shape_suffix = self._get_shape_suffix()  # suffix is important for ensure shape duplicates are removed.
+        self._form_name = self._get_form_name()
+
+    def _get_shape_suffix(self) -> str:
+        return "_id"
+
+    def _get_shape_prefix(self) -> str:
+        return "_cprop_"
+
+    def _get_form_name(self) -> str:
+        return "CellCustomProperties"
 
     def _get_hidden_control_simple(self, name: str) -> HiddenControl | None:
         frm = self._get_form()
@@ -37,7 +46,6 @@ class CustomPropBase(TheDictionaryPartial):
         return name
 
     def _get_form(self) -> Form:
-
         key = self._form_name
         if key in self._cache:
             return self._cache[key]

--- a/ooodev/meta/custom_ext.py
+++ b/ooodev/meta/custom_ext.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import override as override
+else:
+
+    def override(func):  # noqa: ANN001, ANN201
+        return func

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ooo-dev-tools"
-version = "0.52.3"
+version = "0.52.4"
 
 description = "LibreOffice Developer Tools"
 license = "Apache Software License"
 readme = "README.rst"
 authors = [
-    ":Barry-Thomas-Paul: Moss <bigbytetech@gmail.com>"
+    ":Barry-Thomas-Paul: Moss <ooodevtools@pm.amourspirit.net>"
 ]
 keywords = ["ooodev", "libreoffice", "openoffice", "macro", "uno", "ooouno", "pyuno"]
 homepage = "https://github.com/Amourspirit/python_ooo_dev_tools"

--- a/tests/test_calc/test_calc_ns/test_calc_cell_unique_id.py
+++ b/tests/test_calc/test_calc_ns/test_calc_cell_unique_id.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+import pytest
+from pathlib import Path
+
+if __name__ == "__main__":
+    pytest.main([__file__])
+
+
+def test_unique_id(loader, tmp_path) -> None:
+    # Test adding controls to a cell and a range
+    # The controls are found when calling "cell.control.current_control" by shape position.
+    from ooodev.calc import CalcDoc
+
+    doc = None
+    pth = Path(tmp_path, "test_unique_id.ods")
+    id1 = ""
+    id2 = ""
+    id3 = ""
+    try:
+        doc = CalcDoc.create_doc(loader)
+        sheet = doc.sheets[0]
+        cell1 = sheet["A1"]
+        cell1.value = "sheet1.cellA1"
+        id1 = cell1.unique_id
+        assert len(id1) > 0
+        assert cell1.unique_id == id1
+
+        cell2 = sheet["A2"]
+        cell2.value = "sheet1.cellA2"
+        id2 = cell2.unique_id
+        assert len(id2) > 0
+        assert cell2.unique_id == id2
+        assert cell1.unique_id != cell2.unique_id
+
+        sheet2 = doc.sheets.insert_sheet("MySheet2")
+        cell3 = sheet2["A1"]
+        cell3.value = "sheet2.cellA1"
+        id3 = cell3.unique_id
+        assert len(id3) > 0
+        assert cell3.unique_id == id3
+        assert cell1.unique_id != cell3.unique_id
+
+        doc.save_doc(pth)
+
+    finally:
+        if doc is not None:
+            doc.close()
+
+    assert id1
+    assert id2
+    assert id3
+    assert pth.exists()
+    assert pth.is_file()
+    doc = None
+    try:
+        doc = CalcDoc.open_doc(pth)
+        sheet = doc.sheets[0]
+        cell1 = sheet["A1"]
+        assert cell1.unique_id == id1
+        cell2 = sheet["A2"]
+        assert cell2.unique_id == id2
+
+        sheet2 = doc.sheets[1]
+        cell3 = sheet2["A1"]
+        assert cell3.unique_id == id3
+
+        # delete column a1 from sheet 1
+        sheet.delete_row(0)
+        cell1 = sheet["A1"]
+        assert cell1.value == "sheet1.cellA2"
+        assert cell1.unique_id == id2
+
+        sheet2.insert_row(0)
+        cell3 = sheet2["A2"]
+        assert cell3.value == "sheet2.cellA1"
+        assert cell3.unique_id == id3
+    finally:
+        if doc is not None:
+            doc.close()


### PR DESCRIPTION
This pull request introduces a new feature to the `ooodev.calc.CalcCell` class by adding a `unique_id` property to identify cells uniquely, even if they are moved. Additionally, it includes some refactoring and minor improvements.

New Feature:

* [`ooodev/calc/calc_cell.py`](diffhunk://#diff-647e6a6e3ded13898f412c662fec49c6782d4c1ede64eeec6e48cc59d58d2fdfR138): Added a `unique_id` property to the `CalcCell` class. This property generates a unique identifier for each cell, which remains constant even if the cell is moved. [[1]](diffhunk://#diff-647e6a6e3ded13898f412c662fec49c6782d4c1ede64eeec6e48cc59d58d2fdfR138) [[2]](diffhunk://#diff-647e6a6e3ded13898f412c662fec49c6782d4c1ede64eeec6e48cc59d58d2fdfR816-R841)

Refactoring and Improvements:

* [`ooodev/calc/cell/custom_prop.py`](diffhunk://#diff-fd613801c2b1d507f002ea3dd737ad2d23b0032b2ba2b3ffc7ff1db63b4fba03R21): Introduced the `override` decorator to various methods to improve code readability and maintainability. Also, added a check to prevent the removal of the `unique_id` custom property. [[1]](diffhunk://#diff-fd613801c2b1d507f002ea3dd737ad2d23b0032b2ba2b3ffc7ff1db63b4fba03R21) [[2]](diffhunk://#diff-fd613801c2b1d507f002ea3dd737ad2d23b0032b2ba2b3ffc7ff1db63b4fba03L72-R98) [[3]](diffhunk://#diff-fd613801c2b1d507f002ea3dd737ad2d23b0032b2ba2b3ffc7ff1db63b4fba03R481-R482)
* [`ooodev/calc/cell/custom_prop_base.py`](diffhunk://#diff-ca9b508af32b3292e1e05c780f3a17a3d706324598fd5439681c9b99dd52440aL17-R31): Refactored to use getter methods for shape prefix, shape suffix, and form name, improving code clarity and flexibility. [[1]](diffhunk://#diff-ca9b508af32b3292e1e05c780f3a17a3d706324598fd5439681c9b99dd52440aL17-R31) [[2]](diffhunk://#diff-ca9b508af32b3292e1e05c780f3a17a3d706324598fd5439681c9b99dd52440aL40)

Documentation and Testing:

* [`docs/version/version_hist.rst`](diffhunk://#diff-aeaccdc0a7afb1bc10deea7c944aafd1c543c01bb0d998762b85fac253457a7aR5-R9): Updated the version history to include the new `unique_id` feature for `CalcCell`.
* [`tests/test_calc/test_calc_ns/test_calc_cell_unique_id.py`](diffhunk://#diff-437f7915cb9e023789868f15e4629fb06a97003588fcbb6e63d9a9a687966c54R1-R79): Added tests to verify the functionality of the `unique_id` property in various scenarios, ensuring its consistency and correctness.

Version Update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R13): Updated the project version to 0.52.4 and modified the author's contact information.