### PR TITLE
NULL_OBJ now is false in truthy check

### DIFF
--- a/docs/version/version_hist.rst
+++ b/docs/version/version_hist.rst
@@ -2,6 +2,12 @@
 Version History
 ***************
 
+Version 0.52.5
+==============
+
+Updated ``ooodev.utils.gen_util.NULL_OBJ`` constant. This constant is used when ``None`` is not an option.
+Now the constant returns ``False`` in boolean context.
+
 Version 0.52.4
 ==============
 

--- a/ooodev/utils/gen_util.py
+++ b/ooodev/utils/gen_util.py
@@ -15,10 +15,30 @@ import string
 _REG_TO_SNAKE = re.compile(r"(?<!^)(?=[A-Z])|(?<=[A-zA-Z])(?=[0-9])")  # re.compile(r"(?<!^)(?=[A-Z])")
 _REG_LETTER_AFTER_NUMBER = re.compile(r"(?<=\d)(?=[a-zA-Z])")
 
-NULL_OBJ = object()
-"""Null Object uses with None is not an option"""
 
-TNullObj = TypeVar("TNullObj", bound=object)
+class _null_obj:
+    def __bool__(self) -> bool:
+        return False
+
+
+NULL_OBJ = _null_obj()
+"""
+Null Object uses when None is not an option. Truthy value is ``False``
+
+.. versionchanged:: 0.52.5
+    NULL_OBJ now returns ``False`` in boolean context.
+
+.. code-block:: python
+
+    if NULL_OBJ:
+        print("This will never be printed")
+
+    if not NULL_OBJ:
+        print("This will always be printed")
+"""
+# tested in: tests/test_utils/test_null_obj.py
+
+TNullObj = TypeVar("TNullObj", bound=_null_obj)
 
 
 class ArgsHelper:
@@ -26,6 +46,7 @@ class ArgsHelper:
 
     class NameValue(NamedTuple):
         "Name Value pair"
+
         name: str
         """Name component"""
         value: Any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ooo-dev-tools"
-version = "0.52.4"
+version = "0.52.5"
 
 description = "LibreOffice Developer Tools"
 license = "Apache Software License"

--- a/tests/test_utils/test_null_obj.py
+++ b/tests/test_utils/test_null_obj.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import pytest
+
+if __name__ == "__main__":
+    pytest.main([__file__])
+
+
+def test_null_obj() -> None:
+    from ooodev.utils.gen_util import NULL_OBJ
+
+    # Test that NULL_OBJ evaluates to False in boolean context
+    assert bool(NULL_OBJ) is False
+
+    # Test in if statement context
+    if NULL_OBJ:
+        pytest.fail("NULL_OBJ should evaluate to False")
+
+    # Test that NULL_OBJ is not None
+    assert NULL_OBJ is not None
+
+    # Test that multiple NULL_OBJ references point to the same instance
+    from ooodev.utils.gen_util import NULL_OBJ as NULL_OBJ2
+
+    assert NULL_OBJ is NULL_OBJ2
+
+    x = NULL_OBJ
+    if x:
+        pytest.fail("NULL_OBJ should evaluate to False")


### PR DESCRIPTION
This pull request includes updates to the `NULL_OBJ` implementation in `ooodev/utils/gen_util.py`, version bump in `pyproject.toml`, and the addition of new tests.

Updates to `NULL_OBJ`:

* [`ooodev/utils/gen_util.py`](diffhunk://#diff-d29c67a7608052e458e54057483bf4fdd29ec6a750931b113d76f89f70a24a07L18-R49): Replaced the `NULL_OBJ` constant with a class `_null_obj` that overrides the `__bool__` method to return `False`. This ensures `NULL_OBJ` evaluates to `False` in boolean contexts.

Version bump:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the version from `0.52.4` to `0.52.5`.

New tests:

* [`tests/test_utils/test_null_obj.py`](diffhunk://#diff-ca8ca192898744a4676ba477d707eff2d5caf2737e9b409883b1984de8c93eb7R1-R28): Added tests to verify the behavior of `NULL_OBJ`, ensuring it evaluates to `False` in boolean contexts, is not `None`, and that multiple references point to the same instance.