### PR TITLE
Add get_doc method to Lo class and update from_current_doc to support…

### DIFF
--- a/docs/version/version_hist.rst
+++ b/docs/version/version_hist.rst
@@ -2,6 +2,14 @@
 Version History
 ***************
 
+Version 0.53.3
+==============
+
+Added ``Lo.get_doc()`` method. This method can be used to get a document from the desktop components.
+If uid is not empty then the document with the matching uid is returned.
+
+Now when using ``from_current_doc()`` to load a document the uid (RuntimeUID) can be used to get a specific document.
+
 Version 0.53.2
 ==============
 

--- a/ooodev/exceptions/ex.py
+++ b/ooodev/exceptions/ex.py
@@ -19,6 +19,12 @@ class NotFoundError(Exception):
     pass
 
 
+class DocumentNotFoundError(NotFoundError):
+    """Generic Document Not Found Error"""
+
+    pass
+
+
 class MissingNameError(NotFoundError):
     """
     Error when a name is not found.

--- a/ooodev/loader/inst/lo_inst.py
+++ b/ooodev/loader/inst/lo_inst.py
@@ -2300,10 +2300,9 @@ class LoInst(EventsPartial):
                     self._current_doc = None
             if self._current_doc is None:
                 self._logger.debug("current_doc: Could not access current document. Returning None")
-                return self._current_doc
             else:
                 self._logger.debug("current_doc: Got current document from desktop")
-                return self._current_doc
+        return self._current_doc
 
     @current_doc.setter
     def current_doc(self, value: OfficeDocumentT | XComponent | None) -> None:

--- a/ooodev/loader/lo.py
+++ b/ooodev/loader/lo.py
@@ -347,6 +347,26 @@ class Lo(metaclass=StaticProperty):
         return cls._lo_inst.get_desktop()
 
     @classmethod
+    def get_doc(cls, uid: str = "") -> OfficeDocumentT | None:
+        """
+        Gets a document from the desktop components.
+        If uid is not empty then the document with the matching uid is returned.
+
+        Args:
+            uid (str, optional): Unique ID of document.
+                This is usually a single integer pass as a string.
+                For instance the first open document has a uid of ``'1'``.
+                If empty then the first document found is used.
+                Defaults to "".
+
+        Returns:
+            OfficeDocumentT | None: Office Document or None if not a valid document.
+
+        .. versionadded:: 0.53.3
+        """
+        return cls._lo_inst.get_doc(uid)
+
+    @classmethod
     def get_component_factory(cls) -> XMultiComponentFactory:
         """
         Gets current multi component factory.

--- a/ooodev/office/chart2.py
+++ b/ooodev/office/chart2.py
@@ -174,6 +174,9 @@ class Chart2:
             if cells_range is None:
                 raise mEx.NoneError("unable to obtain cells_range, Calc.get_selected_addr() is None")
 
+            if cells_range.Sheet < 0:
+                raise ValueError("Sheet index must be greater then 0")
+
             if not cell_name:
                 cell_name = mCalc.Calc.get_cell_str(col=cells_range.EndColumn + 1, row=cells_range.StartRow)
 

--- a/ooodev/utils/data_type/range_obj.py
+++ b/ooodev/utils/data_type/range_obj.py
@@ -88,7 +88,7 @@ class RangeObj:
         if self.sheet_idx == -1:
             with contextlib.suppress(Exception):
                 # pylint: disable=no-member
-                if mLo.Lo.is_loaded and mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:
+                if mLo.Lo.is_loaded and mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:  # type: ignore
                     doc = cast("CalcDoc", mLo.Lo.current_doc)
                     sheet = doc.get_active_sheet()
                     idx = sheet.get_sheet_index()
@@ -155,13 +155,17 @@ class RangeObj:
         if idx is None:
             try:
                 # pylint: disable=no-member
-                if mLo.Lo.is_loaded and mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:
-                    doc = cast("CalcDoc", mLo.Lo.current_doc)
-                    sheet = doc.get_active_sheet()
-                    idx = sheet.get_sheet_index()
-                    name = sheet.name
-                    object.__setattr__(self, "sheet_idx", idx)
-                    object.__setattr__(self, "_sheet_name", name)
+
+                if mLo.Lo.is_loaded:
+                    if mLo.Lo.current_doc is None:
+                        raise mEx.DocumentNotFoundError("Current document is None")
+                    if mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:
+                        doc = cast("CalcDoc", mLo.Lo.current_doc)
+                        sheet = doc.get_active_sheet()
+                        idx = sheet.get_sheet_index()
+                        name = sheet.name
+                        object.__setattr__(self, "sheet_idx", idx)
+                        object.__setattr__(self, "_sheet_name", name)
             except Exception:
                 object.__setattr__(self, "sheet_idx", -1)
                 if hasattr(self, "_sheet_name"):
@@ -201,7 +205,6 @@ class RangeObj:
         """
 
         def handel_event(args: CancelEventArgs, idx: int) -> tuple:
-
             ret_val = None
             if args.cancel:
                 if args.handled is False:
@@ -259,7 +262,7 @@ class RangeObj:
             if sheet_idx == -1:
                 with contextlib.suppress(Exception):
                     # pylint: disable=no-member
-                    if mLo.Lo.is_loaded and mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:
+                    if mLo.Lo.is_loaded and mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:  # type: ignore
                         doc = cast("CalcDoc", mLo.Lo.current_doc)
                         sheet = doc.get_sheet(sheet_name=sheet_name)
                         sheet_idx = sheet.get_sheet_index()
@@ -881,7 +884,7 @@ class RangeObj:
                 return name
             with contextlib.suppress(Exception):
                 # pylint: disable=no-member
-                if mLo.Lo.is_loaded and mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:
+                if mLo.Lo.is_loaded and mLo.Lo.current_doc.DOC_TYPE == DocType.CALC:  # type: ignore
                     doc = cast("CalcDoc", mLo.Lo.current_doc)
                     sheet = doc.sheets[self.sheet_idx]
                     name = sheet.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ooo-dev-tools"
-version = "0.53.2"
+version = "0.53.3"
 
 description = "LibreOffice Developer Tools"
 license = "Apache Software License"

--- a/tests/test_chart2/test_chart2_direct_title.py
+++ b/tests/test_chart2/test_chart2_direct_title.py
@@ -30,8 +30,9 @@ def test_insert_chart(loader, copy_fix_calc) -> None:
 
     fix_path = cast(Path, copy_fix_calc("chartsData.ods"))
 
-    doc = Calc.open_doc(fix_path)
+    doc = None
     try:
+        doc = Calc.open_doc(fix_path)
         sheet = Calc.get_sheet(doc)
         if not Lo.bridge_connector.headless:
             GUI.set_visible()
@@ -51,7 +52,8 @@ def test_insert_chart(loader, copy_fix_calc) -> None:
 
         Lo.delay(delay)
     finally:
-        Lo.close_doc(doc)
+        if doc is not None:
+            Lo.close_doc(doc)
 
 
 def test_insert_chart_named_sheet(loader, copy_fix_calc) -> None:


### PR DESCRIPTION
This pull request introduces several new features and improvements, primarily focusing on document handling within the `ooodev` package. The most notable changes include the addition of a new method to retrieve documents by unique ID, updates to existing methods to support this new functionality, and documentation updates to reflect these changes.

### New Features:
* Added `get_doc()` method in `ooodev/loader/inst/lo_inst.py` to retrieve a document by its unique ID (RuntimeUID) or the first available document if no ID is provided.
* Added `get_doc()` method in `ooodev/loader/lo.py` to provide a class-level method to retrieve documents by unique ID.

### Method Updates:
* Updated `from_current_doc()` method in `ooodev/utils/partial/doc_io_partial.py` to accept an optional `uid` parameter for retrieving a specific document by its unique ID. [[1]](diffhunk://#diff-5be5cdd73878920e725e30991b0e09e000924898c91f8acfb98dfbf59541aa8bL503-R518) [[2]](diffhunk://#diff-5be5cdd73878920e725e30991b0e09e000924898c91f8acfb98dfbf59541aa8bL524-R534) [[3]](diffhunk://#diff-5be5cdd73878920e725e30991b0e09e000924898c91f8acfb98dfbf59541aa8bL540-R550) [[4]](diffhunk://#diff-5be5cdd73878920e725e30991b0e09e000924898c91f8acfb98dfbf59541aa8bR559-R578)
* Refactored `current_doc()` method in `ooodev/loader/inst/lo_inst.py` to use the new `get_doc()` method for retrieving the current document.

### Documentation Updates:
* Updated version history in `docs/version/version_hist.rst` to include the new version 0.53.3 and document the addition of the `get_doc()` method and the `uid` parameter in `from_current_doc()`.

### Miscellaneous:
* Updated the version number in `pyproject.toml` to 0.53.3.

These changes improve the flexibility and functionality of document handling within the `ooodev` package, allowing for more precise document retrieval and better support for multiple open documents.